### PR TITLE
Issue #14 cancel all bids

### DIFF
--- a/contracts/auction/EnglishPeriodicAuctionInternal.sol
+++ b/contracts/auction/EnglishPeriodicAuctionInternal.sol
@@ -413,11 +413,20 @@ abstract contract EnglishPeriodicAuctionInternal is
     /**
      * @notice Cancel bids for all rounds
      */
-    function _cancelAllBids(uint256 tokenId, address bidder) internal {
+    function _cancelAllBids(
+        uint256 tokenId,
+        uint256 round,
+        address bidder
+    ) internal {
         EnglishPeriodicAuctionStorage.Layout
             storage l = EnglishPeriodicAuctionStorage.layout();
 
         uint256 currentAuctionRound = l.currentAuctionRound[tokenId];
+
+        require(
+            bidder != l.highestBids[tokenId][round].bidder,
+            'EnglishPeriodicAuction: Cannot cancel bid if highest bidder'
+        );
 
         for (uint256 i = 0; i <= currentAuctionRound; i++) {
             Bid storage bid = l.bids[tokenId][i][bidder];

--- a/contracts/auction/facets/EnglishPeriodicAuctionFacet.sol
+++ b/contracts/auction/facets/EnglishPeriodicAuctionFacet.sol
@@ -184,8 +184,11 @@ contract EnglishPeriodicAuctionFacet is
     /**
      * @notice Cancel all bids and withdraw collateral
      */
-    function cancelAllBidsAndWithdrawCollateral(uint256 tokenId) external {
-        _cancelAllBids(tokenId, msg.sender);
+    function cancelAllBidsAndWithdrawCollateral(
+        uint256 tokenId,
+        uint256 round
+    ) external {
+        _cancelAllBids(tokenId, round, msg.sender);
         _withdrawCollateral(msg.sender);
     }
 

--- a/test/auction/EnglishPeriodicAuction.ts
+++ b/test/auction/EnglishPeriodicAuction.ts
@@ -212,7 +212,7 @@ describe('EnglishPeriodicAuction', function () {
           facetFactory.interface.getSighash('auctionEndTime(uint256)'),
           facetFactory.interface.getSighash('cancelBid(uint256,uint256)'),
           facetFactory.interface.getSighash(
-            'cancelAllBidsAndWithdrawCollateral(uint256)',
+            'cancelAllBidsAndWithdrawCollateral(uint256, uint256)',
           ),
           facetFactory.interface.getSighash(
             'cancelBidAndWithdrawCollateral(uint256,uint256)',
@@ -1626,7 +1626,7 @@ describe('EnglishPeriodicAuction', function () {
         .placeBid(0, bidAmount, { value: collateralAmount });
 
       await expect(
-        instance.connect(bidder1).cancelAllBidsAndWithdrawCollateral(0),
+        instance.connect(bidder1).cancelAllBidsAndWithdrawCollateral(0, 0),
       ).to.be.revertedWith(
         'EnglishPeriodicAuction: Cannot cancel bid if highest bidder',
       );
@@ -1830,7 +1830,7 @@ describe('EnglishPeriodicAuction', function () {
       );
       const res = await instance
         .connect(bidder1)
-        .cancelAllBidsAndWithdrawCollateral(0);
+        .cancelAllBidsAndWithdrawCollateral(0, 0);
       const receipt = await res.wait();
       const gasFee = receipt.gasUsed.mul(res.gasPrice);
 
@@ -1884,7 +1884,7 @@ describe('EnglishPeriodicAuction', function () {
       );
       const res = await instance
         .connect(bidder2)
-        .cancelAllBidsAndWithdrawCollateral(0);
+        .cancelAllBidsAndWithdrawCollateral(0, 0);
       const receipt = await res.wait();
       const gasFee = receipt.gasUsed.mul(res.gasPrice);
 

--- a/test/auction/EnglishPeriodicAuction.ts
+++ b/test/auction/EnglishPeriodicAuction.ts
@@ -1608,6 +1608,30 @@ describe('EnglishPeriodicAuction', function () {
       );
     });
 
+    it('should revert if highest bidder tries to cancel all bids', async function () {
+      // Auction start: Now - 200
+      // Auction end: Now + 100
+      const instance = await getInstance({
+        auctionLengthSeconds: 300,
+        initialPeriodStartTime: (await time.latest()) - 200,
+        licensePeriod: 1000,
+      });
+
+      const bidAmount = ethers.utils.parseEther('1.1');
+      const feeAmount = await instance.calculateFeeFromBid(bidAmount);
+      const collateralAmount = feeAmount.add(bidAmount);
+
+      await instance
+        .connect(bidder1)
+        .placeBid(0, bidAmount, { value: collateralAmount });
+
+      await expect(
+        instance.connect(bidder1).cancelAllBidsAndWithdrawCollateral(0),
+      ).to.be.revertedWith(
+        'EnglishPeriodicAuction: Cannot cancel bid if highest bidder',
+      );
+    });
+
     it('should revert if highest bidder tries to cancel bid after auction ends', async function () {
       // Auction start: Now - 200
       // Auction end: Now + 100


### PR DESCRIPTION
Fix #14

Winning bidder was able to cancel all bids, bypassing check and enforcement to withdraw their collateral.  Issue was fixed by adding a "round" parameter to the function call just like the pre-existing `cancelBid(uint256 tokenId, uint256 round)`.

It's worth noting that the function signature of `cancelAllBidsAndWithdrawCollateral(uint256 tokenId)` is now `cancelAllBidsAndWithdrawCollateral(uint256 tokenId, uint256 round)` - so the Front-End function call will have to be modified.