### PR TITLE
test, reproduce and fix

### DIFF
--- a/contracts/auction/EnglishPeriodicAuctionInternal.sol
+++ b/contracts/auction/EnglishPeriodicAuctionInternal.sol
@@ -418,8 +418,17 @@ abstract contract EnglishPeriodicAuctionInternal is
             storage l = EnglishPeriodicAuctionStorage.layout();
 
         uint256 currentAuctionRound = l.currentAuctionRound[tokenId];
+        uint256 availableAuctionRound = currentAuctionRound;
+        if (bidder == l.highestBids[tokenId][currentAuctionRound].bidder) {
+            if (currentAuctionRound == 0) {
+                revert(
+                    'EnglishPeriodicAuction: Cannot cancel bid if highest bidder'
+                );
+            }
+            availableAuctionRound = currentAuctionRound - 1;
+        }
 
-        for (uint256 i = 0; i <= currentAuctionRound; i++) {
+        for (uint256 i = 0; i <= availableAuctionRound; i++) {
             Bid storage bid = l.bids[tokenId][i][bidder];
 
             if (bid.collateralAmount > 0) {

--- a/test/auction/EnglishPeriodicAuction.ts
+++ b/test/auction/EnglishPeriodicAuction.ts
@@ -1608,6 +1608,30 @@ describe('EnglishPeriodicAuction', function () {
       );
     });
 
+    it('should revert if highest bidder tries to cancel all bids', async function () {
+      // Auction start: Now - 200
+      // Auction end: Now + 100
+      const instance = await getInstance({
+        auctionLengthSeconds: 300,
+        initialPeriodStartTime: (await time.latest()) - 200,
+        licensePeriod: 1000,
+      });
+
+      const bidAmount = ethers.utils.parseEther('1.1');
+      const feeAmount = await instance.calculateFeeFromBid(bidAmount);
+      const collateralAmount = feeAmount.add(bidAmount);
+
+      await instance
+        .connect(bidder1)
+        .placeBid(0, bidAmount, { value: collateralAmount });
+
+      await expect(
+        instance.connect(bidder1).cancelAllBidsAndWithdrawCollateral(0),
+      ).to.be.revertedWith(
+        'EnglishPeriodicAuction: Cannot cancel bid if highest bidder',
+      );
+    });
+
     it('should revert if highest bidder tries to cancel bid after auction ends', async function () {
       // Auction start: Now - 200
       // Auction end: Now + 100


### PR DESCRIPTION
Fixes #14

This is the non-naive fix for highest bidder being able to cancel all bids even when they were the winning bidder.  The previous Sherlock proposed fix modified the function signature and resulted in poor UX ... IE user would be unable to cancel all bids from previous rounds while they were the winning bidder of the current round.  It also broke the capability of single function execution retrieval of collateral of multiple bids.

`_cancelAllBids` is now aware of the winner of the current round.  If the user is the winner of the current round; then we decrement the round iterator counter; so that we only iterate through all of the previous rounds - and not iterate through the current round.  It also reverts automatically if we are on the first round `0` ... which is probably redundant because of automatic underflow checks.

```
    /**
     * @notice Cancel bids for all rounds
     */
    function _cancelAllBids(uint256 tokenId, address bidder) internal {
        EnglishPeriodicAuctionStorage.Layout
            storage l = EnglishPeriodicAuctionStorage.layout();

        uint256 currentAuctionRound = l.currentAuctionRound[tokenId];
        uint256 availableAuctionRound = currentAuctionRound;
        if (bidder == l.highestBids[tokenId][currentAuctionRound].bidder) {
            if (currentAuctionRound == 0) {
                revert(
                    'EnglishPeriodicAuction: Cannot cancel bid if highest bidder'
                );
            }
            availableAuctionRound = currentAuctionRound - 1;
        }

        for (uint256 i = 0; i <= availableAuctionRound; i++) {
            Bid storage bid = l.bids[tokenId][i][bidder];

            if (bid.collateralAmount > 0) {
                // Make collateral available to withdraw
                l.availableCollateral[bidder] += bid.collateralAmount;

                // Reset collateral and bid
                bid.collateralAmount = 0;
                bid.bidAmount = 0;
            }
        }
    }
    ```