### PR TITLE
tested, reproduced and fixed

### DIFF
--- a/contracts/auction/EnglishPeriodicAuctionInternal.sol
+++ b/contracts/auction/EnglishPeriodicAuctionInternal.sol
@@ -327,7 +327,7 @@ abstract contract EnglishPeriodicAuctionInternal is
             feeAmount = totalCollateralAmount;
         } else {
             require(
-                totalCollateralAmount > bidAmount,
+                totalCollateralAmount >= bidAmount,
                 'EnglishPeriodicAuction: Collateral must be greater than current bid'
             );
             // If new bidder, collateral is bidAmount + fee
@@ -608,6 +608,9 @@ abstract contract EnglishPeriodicAuctionInternal is
         uint256 feeDenominator = IPeriodicPCOParamsReadable(address(this))
             .feeDenominator();
 
+        if (feeNumerator == 0 || feeDenominator == 0) {
+            return 0;
+        }
         return (bidAmount * feeNumerator) / feeDenominator;
     }
 

--- a/test/auction/EnglishPeriodicAuction.ts
+++ b/test/auction/EnglishPeriodicAuction.ts
@@ -256,6 +256,251 @@ describe('EnglishPeriodicAuction', function () {
     return instance;
   }
 
+  async function getZeroHonorariumInstance({
+    hasOwner = false,
+    auctionLengthSeconds = 100,
+    licensePeriod = 1,
+    initialPeriodStartTime = 2,
+    initialPeriodStartTimeOffset = 0,
+    startingBid = ethers.utils.parseEther('1'),
+    bidExtensionWindowLengthSeconds = 10,
+    bidExtensionSeconds = 20,
+    shouldMint = false,
+    repossessor = nonOwner.address,
+    initialBidder = owner.address,
+  } = {}) {
+    const pcoParamsFacetFactory = await ethers.getContractFactory(
+      'PeriodicPCOParamsFacet',
+    );
+    const pcoParamsFacetInstance = await pcoParamsFacetFactory.deploy();
+    await pcoParamsFacetInstance.deployed();
+
+    const licenseMockFactory = await ethers.getContractFactory(
+      'NativeStewardLicenseMock',
+    );
+    const licenseMock = await licenseMockFactory.deploy();
+    await licenseMock.deployed();
+
+    const beneficiaryFactory = await ethers.getContractFactory(
+      'BeneficiaryMock',
+    );
+    const beneficiaryMock = await beneficiaryFactory.deploy();
+    await beneficiaryMock.deployed();
+
+    const allowlistFactory = await ethers.getContractFactory('AllowlistMock');
+    const allowlistMock = await allowlistFactory.deploy();
+    await allowlistMock.deployed();
+
+    const accessControlFactory = await ethers.getContractFactory(
+      'AccessControlFacet',
+    );
+    const accessControl = await accessControlFactory.deploy();
+    await accessControl.deployed();
+
+    const facetFactory = await ethers.getContractFactory(
+      'EnglishPeriodicAuctionFacet',
+    );
+    const facetInstance = await facetFactory.deploy();
+    await facetInstance.deployed();
+
+    const factory = await ethers.getContractFactory('SingleCutDiamond');
+    instance = await factory.deploy([
+      {
+        target: pcoParamsFacetInstance.address,
+        initTarget: pcoParamsFacetInstance.address,
+        initData: pcoParamsFacetInstance.interface.encodeFunctionData(
+          'initializePCOParams(address,uint256,uint256,uint256)',
+          [await owner.getAddress(), licensePeriod, 0, 10],
+        ),
+        selectors: [
+          pcoParamsFacetInstance.interface.getSighash(
+            'initializePCOParams(address,uint256,uint256,uint256)',
+          ),
+          pcoParamsFacetInstance.interface.getSighash('licensePeriod()'),
+          pcoParamsFacetInstance.interface.getSighash(
+            'setLicensePeriod(uint256)',
+          ),
+          pcoParamsFacetInstance.interface.getSighash('feeNumerator()'),
+          pcoParamsFacetInstance.interface.getSighash('feeDenominator()'),
+        ],
+      },
+      {
+        target: licenseMock.address,
+        initTarget: licenseMock.address,
+        initData: licenseMock.interface.encodeFunctionData(
+          'initializeStewardLicense(address,address,address,uint256,bool,string,string,string)',
+          [
+            await owner.getAddress(),
+            await owner.getAddress(),
+            await owner.getAddress(),
+            10,
+            shouldMint,
+            'name',
+            'symbol',
+            'tokenURI',
+          ],
+        ),
+        selectors: [
+          licenseMock.interface.getSighash(
+            'initializeStewardLicense(address,address,address,uint256,bool,string,string,string)',
+          ),
+          licenseMock.interface.getSighash(
+            'triggerTransfer(address,address,uint256)',
+          ),
+          licenseMock.interface.getSighash('ownerOf(uint256)'),
+          licenseMock.interface.getSighash('mint(address,uint256)'),
+          licenseMock.interface.getSighash('exists(uint256)'),
+          licenseMock.interface.getSighash(
+            'transferFrom(address,address,uint256)',
+          ),
+          licenseMock.interface.getSighash('maxTokenCount()'),
+          licenseMock.interface.getSighash('mintToken(address,uint256)'),
+          licenseMock.interface.getSighash(
+            'addTokenToCollection(address,string,uint256)',
+          ),
+        ],
+      },
+      {
+        target: beneficiaryMock.address,
+        initTarget: beneficiaryMock.address,
+        initData: beneficiaryMock.interface.encodeFunctionData(
+          'initializeMockBeneficiary(address)',
+          [await nonOwner.getAddress()],
+        ),
+        selectors: [
+          beneficiaryMock.interface.getSighash(
+            'initializeMockBeneficiary(address)',
+          ),
+          beneficiaryMock.interface.getSighash('distribute()'),
+        ],
+      },
+      {
+        target: allowlistMock.address,
+        initTarget: allowlistMock.address,
+        initData: allowlistMock.interface.encodeFunctionData(
+          'setIsAllowed(bool)',
+          [true],
+        ),
+        selectors: [
+          allowlistMock.interface.getSighash('isAllowed(address)'),
+          allowlistMock.interface.getSighash('setIsAllowed(bool)'),
+        ],
+      },
+      {
+        target: facetInstance.address,
+        initTarget: facetInstance.address,
+        initData: hasOwner
+          ? facetInstance.interface.encodeFunctionData(
+              'initializeAuction(address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,uint256)',
+              [
+                await owner.getAddress(),
+                repossessor,
+                initialBidder,
+                initialPeriodStartTime,
+                initialPeriodStartTimeOffset,
+                startingBid,
+                auctionLengthSeconds,
+                200,
+                bidExtensionWindowLengthSeconds,
+                bidExtensionSeconds,
+              ],
+            )
+          : facetInstance.interface.encodeFunctionData(
+              'initializeAuction(address,address,uint256,uint256,uint256,uint256,uint256,uint256,uint256)',
+              [
+                repossessor,
+                initialBidder,
+                initialPeriodStartTime,
+                initialPeriodStartTimeOffset,
+                startingBid,
+                auctionLengthSeconds,
+                200,
+                bidExtensionWindowLengthSeconds,
+                bidExtensionSeconds,
+              ],
+            ),
+        selectors: [
+          hasOwner
+            ? facetFactory.interface.getSighash(
+                'initializeAuction(address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,uint256)',
+              )
+            : facetFactory.interface.getSighash(
+                'initializeAuction(address,address,uint256,uint256,uint256,uint256,uint256,uint256,uint256)',
+              ),
+          facetFactory.interface.getSighash('isAuctionPeriod(uint256)'),
+          facetFactory.interface.getSighash('isReadyForTransfer(uint256)'),
+          facetFactory.interface.getSighash('placeBid(uint256,uint256)'),
+          facetFactory.interface.getSighash('closeAuction(uint256)'),
+          facetFactory.interface.getSighash('calculateFeeFromBid(uint256)'),
+          facetFactory.interface.getSighash('repossessor()'),
+          facetFactory.interface.getSighash('setRepossessor(address)'),
+          facetFactory.interface.getSighash('initialPeriodStartTime()'),
+          facetFactory.interface.getSighash('initialBidder()'),
+          facetFactory.interface.getSighash('setAuctionLengthSeconds(uint256)'),
+          facetFactory.interface.getSighash('auctionLengthSeconds()'),
+          facetFactory.interface.getSighash('minBidIncrement()'),
+          facetFactory.interface.getSighash('setMinBidIncrement(uint256)'),
+          facetFactory.interface.getSighash(
+            'setBidExtensionWindowLengthSeconds(uint256)',
+          ),
+          facetFactory.interface.getSighash(
+            'bidExtensionWindowLengthSeconds()',
+          ),
+          facetFactory.interface.getSighash('bidExtensionSeconds()'),
+          facetFactory.interface.getSighash('setBidExtensionSeconds(uint256)'),
+          facetFactory.interface.getSighash('bidOf(uint256,address)'),
+          facetFactory.interface.getSighash('bidOf(uint256,uint256,address)'),
+          facetFactory.interface.getSighash('highestBid(uint256)'),
+          facetFactory.interface.getSighash('highestBid(uint256,uint256)'),
+          facetFactory.interface.getSighash('currentAuctionRound(uint256)'),
+          facetFactory.interface.getSighash('auctionStartTime(uint256)'),
+          facetFactory.interface.getSighash('auctionEndTime(uint256)'),
+          facetFactory.interface.getSighash('cancelBid(uint256,uint256)'),
+          facetFactory.interface.getSighash(
+            'cancelAllBidsAndWithdrawCollateral(uint256)',
+          ),
+          facetFactory.interface.getSighash(
+            'cancelBidAndWithdrawCollateral(uint256,uint256)',
+          ),
+          facetFactory.interface.getSighash('withdrawCollateral()'),
+          facetFactory.interface.getSighash(
+            'setAuctionParameters(address,uint256,uint256,uint256,uint256,uint256)',
+          ),
+          facetFactory.interface.getSighash('startingBid()'),
+          facetFactory.interface.getSighash('setStartingBid(uint256)'),
+          facetFactory.interface.getSighash('availableCollateral(address)'),
+          facetFactory.interface.getSighash(
+            'lockedCollateral(uint256,address)',
+          ),
+        ],
+      },
+      {
+        target: accessControl.address,
+        initTarget: accessControl.address,
+        initData: accessControl.interface.encodeFunctionData(
+          'initializeAccessControl(address)',
+          [admin.address],
+        ),
+        selectors: [
+          accessControl.interface.getSighash(
+            'initializeAccessControl(address)',
+          ),
+          accessControl.interface.getSighash('grantRole(bytes32,address)'),
+          accessControl.interface.getSighash('renounceRole(bytes32)'),
+          accessControl.interface.getSighash('hasRole(bytes32,address)'),
+        ],
+      },
+    ]);
+    await instance.deployed();
+
+    instance = await ethers.getContractAt(
+      'EnglishPeriodicAuctionFacet',
+      instance.address,
+    );
+
+    return instance;
+  }
+
   before(async function () {
     [owner, nonOwner, bidder1, bidder2, admin] = await ethers.getSigners();
   });
@@ -2682,6 +2927,42 @@ describe('EnglishPeriodicAuction', function () {
       expect(await instance.auctionStartTime(10)).to.equal(
         initialPeriodStartTime + 100,
       );
+    });
+
+    describe('honorarium', function () {
+      it('should allow bidding while honorarium is set to 0', async function () {
+        // Auction start: Now + 100
+        // Auction end: Now + 400
+        const instance = await getZeroHonorariumInstance({
+          auctionLengthSeconds: 300,
+          initialPeriodStartTime: (await time.latest()) + 100,
+          licensePeriod: 1000,
+        });
+        const licenseMock = await ethers.getContractAt(
+          'NativeStewardLicenseMock',
+          instance.address,
+        );
+
+        // Mint token manually
+        const steward = bidder2.address;
+        await licenseMock.mintToken(steward, 0);
+
+        // Start auction
+        await time.increase(300);
+
+        const bidAmount = ethers.utils.parseEther('1.0');
+        const feeAmount = await instance.calculateFeeFromBid(bidAmount);
+        const collateralAmount = feeAmount.add(bidAmount);
+
+        // Reverts when a user tries to place a bid
+        console.log('Placing collateral bid: ', collateralAmount);
+        console.log('Bid Amount: ', bidAmount);
+        await expect(
+          instance
+            .connect(bidder1)
+            .placeBid(0, bidAmount, { value: collateralAmount }),
+        ).to.not.be.reverted;
+      });
     });
   });
 });


### PR DESCRIPTION
Fixes #31

Honorariums set to zero now function correctly.  Great job on the recommendations from Sammy here https://github.com/sherlock-audit/2024-02-radicalxchange-judging/issues/31

The test code made this very easy to reproduce.  I was able to take the recommended fix - with the addition of a simple check against fee numerator or denominators that are zero:

```
    /**
     * @notice Calculate fee from bid
     */
    function _calculateFeeFromBid(
        uint256 bidAmount
    ) internal view returns (uint256) {
        uint256 feeNumerator = IPeriodicPCOParamsReadable(address(this))
            .feeNumerator();
        uint256 feeDenominator = IPeriodicPCOParamsReadable(address(this))
            .feeDenominator();

        if (feeNumerator == 0 || feeDenominator == 0) {
            return 0;
        }
        return (bidAmount * feeNumerator) / feeDenominator;
    }
    ```