### PR TITLE
sanity checks for fee division

### DIFF
--- a/contracts/pco/PeriodicPCOParamsInternal.sol
+++ b/contracts/pco/PeriodicPCOParamsInternal.sol
@@ -16,6 +16,11 @@ abstract contract PeriodicPCOParamsInternal is IPeriodicPCOParamsInternal {
         uint256 feeNumerator,
         uint256 feeDenominator
     ) internal {
+        require(
+            feeDenominator > feeNumerator && feeDenominator < 10_001,
+            'PeriodicPCOParamsInternal: invalid fee'
+        );
+
         PeriodicPCOParamsStorage.Layout storage l = PeriodicPCOParamsStorage
             .layout();
 

--- a/test/pco/PeriodicPCOParams.ts
+++ b/test/pco/PeriodicPCOParams.ts
@@ -112,6 +112,26 @@ describe('PeriodicPCOParams', function () {
       expect(await instance.feeDenominator()).to.be.equal(4);
     });
 
+    it('should not set feeDenominator over 10_000', async function () {
+      const factory = await ethers.getContractFactory('PeriodicPCOParamsFacet');
+      const instance = await factory.deploy();
+      await instance.deployed();
+
+      await expect(
+        instance['initializePCOParams(uint256,uint256,uint256)'](1, 3, 10001),
+      ).to.be.revertedWith('PeriodicPCOParamsInternal: invalid fee');
+    });
+
+    it('should not set numerator higher than denominator', async function () {
+      const factory = await ethers.getContractFactory('PeriodicPCOParamsFacet');
+      const instance = await factory.deploy();
+      await instance.deployed();
+
+      await expect(
+        instance['initializePCOParams(uint256,uint256,uint256)'](1, 5, 4),
+      ).to.be.revertedWith('PeriodicPCOParamsInternal: invalid fee');
+    });
+
     it('should revert if already initialized', async function () {
       const factory = await ethers.getContractFactory('PeriodicPCOParamsFacet');
       const instance = await factory.deploy();


### PR DESCRIPTION
Fixes 92

The suggested fix here was irrelevant - there's already a view function for calculating the fee including any rounding error.  So there's no chance of a mismatch between on-chain and off-chain calculations or dust here.  However some of the other concerns around unbounded numerator and denominator are completely valid.  I added some sanity checks that are pretty standard for any kind of "basis points" in DeFi.

Fee numerator must be lower than denominator (otherwise you get fee amounts in excess of the total bid) - and also enforced that denominator be no more than 10_000 as that gives us precision to describe fees down to the 0.01%